### PR TITLE
fix: add changeset cleanup to release workflow

### DIFF
--- a/.changeset/tough-foxes-clean.md
+++ b/.changeset/tough-foxes-clean.md
@@ -1,0 +1,5 @@
+---
+'better-react-state': patch
+---
+
+Add automatic cleanup of consumed changesets after release sync to prevent version bump issues

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,19 @@ jobs:
           # Merge main into dev
           git merge origin/main -m "chore: sync version from main to dev after release"
           
+          # Clean up consumed changesets that don't exist on main
+          # Pattern matches: word-word-word.md (e.g., quiet-beds-tell.md)
+          # Excludes: README.md, config.json, and other documentation
+          find .changeset -type f -name "*.md" \
+            -regex ".*/[a-z]+-[a-z]+-[a-z]+\.md$" \
+            -delete
+          
+          # Commit the cleanup if any files were deleted
+          if [ -n "$(git status --porcelain .changeset)" ]; then
+            git add .changeset
+            git commit -m "chore: clean consumed changesets after release sync"
+          fi
+          
           # Push the merge back to dev
           git push origin dev
         env:


### PR DESCRIPTION
- Add automatic cleanup of consumed changesets after main-to-dev sync
- Prevents duplicate changesets causing incorrect version bumps
- Uses safe regex pattern to only delete changeset files (word-word-word.md)

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Checklist

- [ ] I have added a changeset for my changes (run `pnpm changeset` if not)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Changeset

<!-- The changeset bot will add a comment here about the changeset status -->

## Related Issues

<!-- Link any related issues here using #issue-number -->

## Additional Notes

<!-- Add any additional notes or context about the PR here -->
